### PR TITLE
Added make to list of packages installed

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Necessary for most go projects `make test`
+apt-get install -y  make
+
 GOSOURCE=https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz
 GOTARGET=/usr/local
 GOPATH=\$HOME/go


### PR DESCRIPTION
I use this project to mount my $GOPATH, so that I may test projects
which only work under Linux.  The ability to run `make` to test these
projects is necessary.  Also, seems to fall in line with the goal of
this project.  One would create a new go project, and should provide
a Makefile to execute tests.